### PR TITLE
Deleted Character Handling

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -86,6 +86,7 @@ sort($european_realm_array);
 // Variables
 $player_count = 0;
 $active_player_count = 0;
+$deleted_player_count = 0;
 $realm_count = array();
 $active_realm_count = array();
 $gc_count = array();
@@ -132,6 +133,11 @@ $beast_tribes["Sylph"] = 0;
 
 $player_overview_query = $db->query("SELECT * FROM tblplayers;", MYSQLI_USE_RESULT);
 while($row = $player_overview_query->fetch_assoc()) {
+        // Skip deleted characters
+        if(isset($row["character_status"]) && $row["character_status"] == "DELETED") {
+            $deleted_player_count++;
+            continue;
+        }
         $realm = isset($row["realm"]) ? $row["realm"] : 'Unknown';
         $grand_company = isset($row["grand_company"]) ?$row["grand_company"] : 'Unknown';
         $race = isset($row["race"]) ? $row["race"] : 'Unknown';
@@ -860,6 +866,13 @@ $db->close();
                       <div class="row">
                         <div class=" s12 m6 l6   region-stat">
                           <div><?php echo $fmt_sightseeing; ?></div>
+                        </div>
+                      </div>
+
+                      <div class="black-text light region-subtitle">DELETED CHARACTERS</div>
+                      <div class="row">
+                        <div class=" s12 m6 l6   region-stat">
+                          <div><?php echo $deleted_player_count; ?></div>
                         </div>
                       </div>
 


### PR DESCRIPTION
Companion change to the [gatherer update](https://github.com/XIVStats/XIVStats-Gatherer-Java/pull/28) that enables recording deleted characters and skipping them from subsequent gathering runs.

Records the number of skipped characters and makes the stat available in the Other section, just for fun.