### PR TITLE
Fix statistics errors on small Databases

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -34,9 +34,14 @@ function sumInRegion($data, $regional_realms) {
         return array_sum(array_intersect_key($data, array_flip($regional_realms)));
 }
 
+// Helper function that returns zero if the value supplied isn't set
+function getValue($value) {
+    return isset($value) ? $value : 0;
+}
+
 // Helper function to return the value of the requested key, or zero if one isn't available
-function getValueOrZero($data, $key) {
-        return isset($data[$key]) ? $data[$key] : 0;
+function getValueFromArray($data, $key) {
+        return getValue($data[$key]);
 }
 
 // Helper function to increment class count into the supplied total array
@@ -935,7 +940,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($gc_count as $key => $value) {
-                                      echo "['$key', $value,],\n";
+                                      echo "['" . $key . "', " . getValue($value) . "],\n";
                               }
                       ?>
                   ]
@@ -969,7 +974,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($active_gc_count as $key => $value) {
-                                      if($key != "none") echo "['$key', $value,],\n";
+                                      echo "['" . $key . "', " . getValue($value) . "],\n";
                               }
                       ?>
                   ]
@@ -1013,7 +1018,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($race_gender_count as $value) {
-                                      echo $value["female"] . ",";
+                                      echo getValueFromArray($value, "female") . ",";
                               }
                       ?>
                   ],
@@ -1022,7 +1027,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($race_gender_count as $value) {
-                                      echo $value["male"] . ",";
+                                      echo getValueFromArray($value,"male") . ",";
                               }
                       ?>
                   ],
@@ -1066,7 +1071,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($active_race_gender_count as $value) {
-                                      echo $value["female"] . ",";
+                                      echo getValueFromArray($value, "female") . ",";
                               }
                       ?>
                   ],
@@ -1075,7 +1080,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($active_race_gender_count as $value) {
-                                      echo $value["male"] . ",";
+                                      echo getValueFromArray($value,"male") . ",";
                               }
                       ?>
                   ],
@@ -1119,7 +1124,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($classes as $key => $value) {
-                                      echo "$value,";
+                                      echo getValue($value) . ",";
                               }
                       ?>
                   ],
@@ -1163,7 +1168,7 @@ $db->close();
                   data: [
                       <?php
                               foreach ($active_classes as $key => $value) {
-                                      echo "$value,";
+                                      echo getValue($value) . ",";
                               }
                       ?>
                   ],
@@ -1208,7 +1213,7 @@ $(function () {
             data: [
                 <?php
                         foreach ($american_realm_array as $value) {
-                                echo getValueOrZero($realm_count, $value) . ",";
+                                echo getValueFromArray($realm_count, $value) . ",";
                         }
                 ?>
             ],
@@ -1253,7 +1258,7 @@ $(function () {
             data: [
                 <?php
                         foreach ($american_realm_array as $value) {
-                                echo getValueOrZero($active_realm_count, $value) . ",";
+                                echo getValueFromArray($active_realm_count, $value) . ",";
                         }
                 ?>
             ],
@@ -1298,7 +1303,7 @@ $(function () {
             data: [
                 <?php
                         foreach ($japanese_realm_array as $value) {
-                                echo getValueOrZero($realm_count, $value) . ",";
+                                echo getValueFromArray($realm_count, $value) . ",";
                         }
                 ?>
             ],
@@ -1343,7 +1348,7 @@ $(function () {
             data: [
                 <?php
                         foreach ($japanese_realm_array as $value) {
-                                echo getValueOrZero($active_realm_count, $value) . ",";
+                                echo getValueFromArray($active_realm_count, $value) . ",";
                         }
                 ?>
             ],
@@ -1388,7 +1393,7 @@ $(function () {
             data: [
                 <?php
                         foreach ($european_realm_array as $value) {
-                                echo getValueOrZero($realm_count, $value) . ",";
+                                echo getValueFromArray($realm_count, $value) . ",";
                         }
                 ?>
             ],
@@ -1433,7 +1438,7 @@ $(function () {
             data: [
                 <?php
                         foreach ($european_realm_array as $value) {
-                                echo getValueOrZero($active_realm_count, $value) . ",";
+                                echo getValueFromArray($active_realm_count, $value) . ",";
                         }
                 ?>
             ],
@@ -1477,7 +1482,7 @@ $(function () {
                   data: [
                       <?php
                               foreach ($sub_time as $key => $value) {
-                                      echo "$value,";
+                                      echo getValue($value) . ",";
                               }
                       ?>
                   ],
@@ -1521,7 +1526,7 @@ $(function () {
                   data: [
                       <?php
                               foreach ($beast_tribes as $key => $value) {
-                                      echo "$value,";
+                                      echo getValue($value) . ",";
                               }
                       ?>
                   ],


### PR DESCRIPTION
Refactored a small about of the PHP that fetches numbers from inside arrays to present on the charts, as there's a possibility with smaller DB's and dev snapshots that the return value from the array will be `nil` and so the Javascript will fail.

See issue #31.