### PR TITLE
Adding new EU worlds

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -88,7 +88,8 @@ $japanese_realm_array = array("Alexander","Bahamut","Durandal","Fenrir","Ifrit",
                               "Atomos","Carbuncle","Garuda","Gungnir","Kujata","Ramuh","Tonberry","Typhon","Unicorn");
 sort($japanese_realm_array);
 
-$european_realm_array = array("Cerberus","Lich","Moogle","Odin","Phoenix","Ragnarok","Shiva","Zodiark","Louisoix","Omega");
+$european_realm_array = array("Cerberus","Lich","Moogle","Odin","Phoenix","Ragnarok","Shiva","Zodiark","Louisoix","Omega",
+                              "Spriggan","Twintania");
 sort($european_realm_array);
 
 // Variables


### PR DESCRIPTION
Quick PR following the Live Letter to add placeholders for the new EU worlds, Spriggan and Twintania.