### PR TITLE
Adding Lodestone link for Wind-up Vrtra that comes with Endwalker OST

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -1218,7 +1218,7 @@ $db->close();
                         </span>
                     </div>
                     <div class="col s12 m4 l4 light region-subtitle">
-                        <p><a href="#" class="eorzeadb_link">ENDWALKER SOUNDTRACK</a></p>
+                        <p><a href="https://eu.finalfantasyxiv.com/lodestone/playguide/db/item/2b855d1b1a1/" class="eorzeadb_link">ENDWALKER SOUNDTRACK</a></p>
                         <span class="region-stat">
                             <?php echo $fmt_ew_soundtrack; ?>
                         </span>


### PR DESCRIPTION
As per title, it adds the Lodestone link for the Endwalker Soundtrack Minion `Wind-up Vrtra` to the page. 

Cool to see that over 22,000+ characters have the minion on them. Sales of the soundtrack seems to be very good!