### PR TITLE
Adds in anchor to fix Grand company section. Fixes #68

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -1011,7 +1011,7 @@ $db->close();
         </div>
         <div class="row card">
             <div class="card-content">
-                <div class="col s12"><span class="card-title light">GRAND COMPANY DISTRIBUTION</span>
+                <div id="grandcompany" class="col s12"><span class="card-title light">GRAND COMPANY DISTRIBUTION</span>
                     <hr>
                     <div class="row">
                         <div class="col s12 m6 l6 light region-subtitle">


### PR DESCRIPTION
As per title, the navigation to the '[GRAND COMPANY STATS](https://ffxivcensus.com/#grandcompany)' was not working. 

This fixes it by reintroducing the anchor link: https://github.com/XIVStats/XIVStats/blob/d4d3a53fc9dc7758f2d548fcdb7fceba710a46b5/xiv_stats.php#L1014

This fixes and closes #68 