### PR TITLE
This adds the 4 new EU servers coming in FFXIV Patch 6.18

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -103,7 +103,7 @@ $japanese_realm_array = array("Alexander","Bahamut","Durandal","Fenrir","Ifrit",
 sort($japanese_realm_array);
 
 $european_realm_array = array("Cerberus","Lich","Moogle","Odin","Phoenix","Ragnarok","Shiva","Zodiark","Louisoix","Omega",
-                              "Spriggan","Twintania");
+                              "Spriggan","Twintania", "Sagittarius", "Phantom", "Alpha", "Raiden");
 sort($european_realm_array);
 
 $oceanian_realm_array = array("Bismarck", "Ravana", "Sephirot", "Sophia", "Zurvan");


### PR DESCRIPTION
As [announced on the Lodestone today](https://eu.finalfantasyxiv.com/lodestone/topics/detail/59c203b8d36cfddc2d49874f96356cad741e8dec), Square Enix are going to be adding 4 new worlds to the EU Datacentre. 2 on Chaos and 2 on Light. 

* Sagittarius (Chaos)
* Phantom (Chaos)
* Alpha (Light)
* Raiden (Light)