### PR TITLE
Adding new 'Dynamis' DC for North America

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -93,7 +93,8 @@ if (! $db->select_db($conn_info["database"])) {
 $american_realm_array = array("Behemoth","Brynhildr","Diabolos","Exodus","Famfrit","Hyperion",
                               "Lamia","Leviathan","Malboro","Ultros","Adamantoise","Balmung",
                               "Cactuar","Coeurl","Faerie","Gilgamesh","Goblin","Jenova","Mateus",
-                              "Midgardsormr","Sargatanas","Siren","Zalera","Excalibur");
+                              "Midgardsormr","Sargatanas","Siren","Zalera","Excalibur",
+                              "Halicarnassus", "Maduin", "Marilith", "Seraph");
 sort($american_realm_array);
 
 $japanese_realm_array = array("Alexander","Bahamut","Durandal","Fenrir","Ifrit","Ridill","Tiamat","Ultima",


### PR DESCRIPTION
As announced in the Letter from the Producer LIVE early this morning, Square Enix is going to be adding a new 'logical data centre' named **Dynamis** on November 1st 2022.

The four new worlds are:

* Halicarnassus
* Maduin
* Marilith
* Seraph

This PR adds support for the 4 new worlds :D 

https://crakila.dev/xiv/feat/new-na-servers/