### PR TITLE
Patch 6.3 - CC Rewards, A11Y, Tweets and Toots !

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -427,7 +427,6 @@ while($row = $player_overview_query->fetch_assoc()) {
     $beast_tribes["Dwarf"] += in_array("Lalinator 5.H0", $minions) || in_array("Rolling Tankard", $mounts) ? 1 : 0;
 
     // Endwalker
-    $beast_tribes["Arkasodara"] += in_array("Wind-up Arkasodara", $minions) ? 1 : 0;
     $beast_tribes["Arkasodara"] += in_array("Wind-up Arkasodara", $minions) || in_array("Hippo Cart", $mounts) ? 1 : 0;
     $beast_tribes["Omnicron"] += in_array("Lumini", $minions) || in_array("Miw Miisv", $mounts) ? 1 : 0;
   
@@ -788,7 +787,6 @@ $db->close();
 
             <!-- Other Stats Dropdown -->
             <ul id='misc-stats-dropdown' class='dropdown-content'>
-                <li><a href="#beast">Beast Tribes</a></li>
                 <li><a href="#tribal">Tribal Quests</a></li>
                 <li><a href="#preorders">Pre-Orders</a></li>
                 <li><a href="#collectors">Collectors Edition</a></li>
@@ -1095,7 +1093,6 @@ $db->close();
         <div class="row">
             <div class="card">
                 <div class="card-content">
-                    <a id="beast"><span class="card-title light">BEAST TRIBES (REDEEMED MINION)</span></a>
                     <a id="tribal"><span class="card-title light">TRIBAL QUESTS (REDEEMED MOUNT OR MINION)</span></a>
                     <hr />
                     <br />

--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -549,6 +549,9 @@ $db->close();
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
     <!-- Highcharts-->
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/exporting.js"></script>
+    <script src="https://code.highcharts.com/modules/export-data.js"></script>
+    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
     <!-- Font Awesome-->
     <script src="https://use.fontawesome.com/42d19261ec.js"></script>
     <!-- Compiled and minified CSS -->

--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -756,6 +756,9 @@ $db->close();
             <a class="waves-effect waves-light btn" href='#grandcompany'>Grand Company Stats</a>
             <a class='dropdown-trigger btn' href='#' data-target='misc-stats-dropdown'>Other Stats</a>
             <a class="waves-effect waves-light btn" href='#top'><i class="fa fa-arrow-up" aria-hidden="true"></i></a>
+            Follow us: 
+            <a href="https://etheirys.masto.host/@ffxivcensus"><i class="fa fa-mastodon" aria-hidden="true"></i></a>
+            <a href="https://twitter.comffxivcensus"><i class="fa fa-twitter" aria-hidden="true"></i></a>
 
             <!-- Population Stats Dropdown -->
             <ul id='pop-dropdown' class='dropdown-content'>

--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -447,6 +447,9 @@ while($row = $player_overview_query->fetch_assoc()) {
             // Series 2 - Level 25 Reward
             $cc_s2l25_reward += in_array("Fylgja", $mounts) ? 1 : 0;
             $fmt_cc_s2l25_reward = number_format($cc_s2l25_reward);
+            // Series 3 - Level 15 Reward
+            $cc_s3l15_reward += in_array("Logistics Node, $mounts") ? 1 : 0;
+            $fmt_cc_s3l15_reward = number_format($cc_s3l15_reward);
 
     // Anniversary Events
     $ninth_anniversary += in_array("Clockwork Solus", $minions) ? 1 : 0;

--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -212,6 +212,7 @@ $literal_whale = 0;
 $pvp_200_wins = 0;
 $cc_s2l1516_reward = 0;
 $cc_s2l25_reward = 0;
+$cc_s3l15_reward = 0;
 
 // Anniversary Events
 $ninth_anniversary = 0;
@@ -448,7 +449,7 @@ while($row = $player_overview_query->fetch_assoc()) {
             $cc_s2l25_reward += in_array("Fylgja", $mounts) ? 1 : 0;
             $fmt_cc_s2l25_reward = number_format($cc_s2l25_reward);
             // Series 3 - Level 15 Reward
-            $cc_s3l15_reward += in_array("Logistics Node, $mounts") ? 1 : 0;
+            $cc_s3l15_reward += in_array("Logistics Node", $mounts) ? 1 : 0;
             $fmt_cc_s3l15_reward = number_format($cc_s3l15_reward);
 
     // Anniversary Events

--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -551,8 +551,8 @@ $db->close();
     <script src="https://code.highcharts.com/modules/exporting.js"></script>
     <script src="https://code.highcharts.com/modules/export-data.js"></script>
     <script src="https://code.highcharts.com/modules/accessibility.js"></script>
-    <!-- Font Awesome-->
-    <script src="https://use.fontawesome.com/42d19261ec.js"></script>
+    <!-- Fork Awesome-->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css" integrity="sha256-XoaMnoYC5TH6/+ihMEnospgm0J1PM/nioxbOUdnM8HY=" crossorigin="anonymous">
     <!-- Compiled and minified CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <!-- Compiled and minified JavaScript -->


### PR DESCRIPTION
Happy Patch 6.3 to all adventurers.

* Added Crystalline Conflict Series 3 reward.
* Improved accessibility with charts. Can now be saved using a menu. 
* Moved from FontAwesome to ForkAwesome (It's basically the same without the paywall) 
* Added Mastodon and Twitter account (This may need adjusting)

There might be a 2nd update for the new gold mount check. (Might see who has all the 'gold' mounts) - But I am awaiting more information - I believe _some_ of the items that were added are not going to become available until Patch 6.35, but I will need to wait and see. 