### PR TITLE
Replacing UA with GA4 tracking code.

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -578,17 +578,14 @@ $db->close();
     });
     </script>
 
-    <!-- Google Analytics -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WXM41K6BMN"></script>
     <script>
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-        ga('create', 'UA-93918116-1', 'auto');
-        ga('send', 'pageview');
+    gtag('config', 'G-WXM41K6BMN');
     </script>
     <style>
         /*


### PR DESCRIPTION
Google UA (Universal Analytics) is being removed on July 1st and is being replaced with GA4 (Google Analytics 4) 

This PR updates the tracking code so that it will work after July 1st. 