### PR TITLE
Added new Dynamis worlds

### DIFF
--- a/xiv_stats.php
+++ b/xiv_stats.php
@@ -94,7 +94,7 @@ $american_realm_array = array("Behemoth","Brynhildr","Diabolos","Exodus","Famfri
                               "Lamia","Leviathan","Malboro","Ultros","Adamantoise","Balmung",
                               "Cactuar","Coeurl","Faerie","Gilgamesh","Goblin","Jenova","Mateus",
                               "Midgardsormr","Sargatanas","Siren","Zalera","Excalibur",
-                              "Halicarnassus", "Maduin", "Marilith", "Seraph");
+                              "Halicarnassus", "Maduin", "Marilith", "Seraph", "Cuchulainn", "Golem", "Kraken", "Rafflesia");
 sort($american_realm_array);
 
 $japanese_realm_array = array("Alexander","Bahamut","Durandal","Fenrir","Ifrit","Ridill","Tiamat","Ultima",


### PR DESCRIPTION
Square Enix has announced the creation of 4 new World on the Dynamis NA Servers.

* Cuchulainn
* Golem
* Kraken
* Rafflesia

These will go live next Tuesday, 11th June 2024.

Source: https://na.finalfantasyxiv.com/lodestone/topics/detail/93750e4b0d6d5a4faf6a00dee199082392f1a754